### PR TITLE
Fix: Files won't open after restart VS Code.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,9 +14,12 @@ export function activate(context: vscode.ExtensionContext) {
       vscode.commands.registerCommand("explorer-bookmark.refreshEntry", () =>
         explorerBookmark.refresh()
       ),
-      vscode.commands.registerCommand("explorer-bookmark.openFile", (file) =>
-        vscode.commands.executeCommand("vscode.open", file.resourceUri)
-      ),
+      vscode.commands.registerCommand("explorer-bookmark.openFile", (file) => {
+        vscode.commands.executeCommand(
+          "vscode.open",
+          vscode.Uri.parse(file.resourceUri.path)
+        );
+      }),
       vscode.commands.registerCommand("explorer-bookmark.selectItem", (args) =>
         explorerBookmark.selectItem(vscode.Uri.parse(args.path))
       ),

--- a/src/provider/ExplorerBookmark.ts
+++ b/src/provider/ExplorerBookmark.ts
@@ -22,8 +22,6 @@ export class ExplorerBookmark
   ) {
     this.getSettings();
     if (this.saveWorkspaceSetting && this.selectedFSObjects.length > 0) {
-      for (const object of this.selectedFSObjects) {
-      }
       this.refresh();
     }
   }


### PR DESCRIPTION
Fixed an issue where single files wouldn't open after they were saved in a previous session. Files from old entry folders worked.